### PR TITLE
Update Gemfiles for Redmine 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'http://rubygems.org'
 
 gem 'oauth2'
-gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,25 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.3.2)
-    faraday (0.7.6)
-      addressable (~> 2.2)
-      multipart-post (~> 1.1)
-      rack (~> 1.1)
-    json (1.7.5)
-    multi_json (1.3.6)
-    multipart-post (1.1.5)
-    oauth2 (0.5.2)
-      faraday (~> 0.7)
-      multi_json (~> 1.0)
-    rack (1.4.1)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
+    jwt (2.2.2)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    rack (2.2.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  json
   oauth2
+
+BUNDLED WITH
+   1.17.2


### PR DESCRIPTION
# Background
- A native build is required to install the json library in original Gemfile{,.lock}.
- There is no C compiler in the official redmine docker image.
- But It is bundled the json library with ruby 2.6 in the official redmine docker image.

# To do
Use the standard json library.
